### PR TITLE
feat: responsive views

### DIFF
--- a/src/components/ColorCombos/index.css
+++ b/src/components/ColorCombos/index.css
@@ -66,3 +66,45 @@
 .color-combos__sample {
   transition: all 700ms;
 }
+
+@media (max-width: 1034px) {
+  .color-combos .fa {
+    margin: 0 10px;
+    font-size: 25px;
+  }
+
+  .color-combos .fa.fa-pause {
+    font-size: 22px;
+  }
+}
+
+@media (max-width: 660px) {
+  .row.res-row {
+    margin: 10px auto;
+  }
+  .color-combos .suggestion {
+    flex-basis: 100%;
+    flex-direction: row;
+    height: auto;
+    padding: 20px 0;
+  }
+
+  .color-combos .suggestion h3 {
+    margin-left: 10px;
+  }
+
+  .color-combos .suggestion [role='group'] {
+    display: flex;
+    flex-wrap: wrap;
+    margin: 0 auto 0 20px;
+    align-items: center;
+  }
+
+  .color-combos .suggestion [role='group'] .swatch {
+    margin-right: 10px;
+  }
+
+  .color-combos .suggestion [role='group'] .dqpl-link {
+    margin-left: 10px;
+  }
+}

--- a/src/components/ColorCombos/index.js
+++ b/src/components/ColorCombos/index.js
@@ -74,9 +74,15 @@ export default class ColorCombos extends Component {
                       <h3 id={`suggestion-${i}`}>Suggestion</h3>
                       <div role="group" aria-labelledby={`suggestion-${i}`}>
                         <Swatch color={suggestion.fg} type="palette" />
-                        <div className="spec">{suggestion.fg}</div>
-                        <div className="spec">{`rgba(${rgba.join(', ')})`}</div>
-                        <div className="spec">{`${suggestion.contrast}:1`}</div>
+                        <div>
+                          <div className="spec">{suggestion.fg}</div>
+                          <div className="spec">{`rgba(${rgba.join(
+                            ', '
+                          )})`}</div>
+                          <div className="spec">{`${
+                            suggestion.contrast
+                          }:1`}</div>
+                        </div>
                         <button
                           className="dqpl-link"
                           onClick={() => {

--- a/src/components/ColorConfig/index.js
+++ b/src/components/ColorConfig/index.js
@@ -1,0 +1,105 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { Subscribe } from 'unstated';
+import { Checkbox } from 'cauldron-react';
+import TextInput from '../TextInput';
+import PaletteContainer from '../../containers/PaletteContainer';
+import TabsContainer from '../../containers/TabsContainer';
+
+export default class ColorConfig extends Component {
+  static propTypes = {
+    color: PropTypes.object.isRequired,
+    i: PropTypes.number.isRequired
+  };
+
+  render() {
+    const {
+      i,
+      color: {
+        hex,
+        text,
+        background,
+        rgba: [r, g, b, a],
+        original
+      }
+    } = this.props;
+
+    return (
+      <Subscribe to={[PaletteContainer, TabsContainer]}>
+        {(
+          { updateColor, swapColor, removeColor, state: { isWide } },
+          { onDelete }
+        ) => (
+          <div
+            className="fields"
+            role="group"
+            aria-labelledby={`cb-label-${i}`}
+          >
+            <div className="row">
+              {original && (
+                <button
+                  aria-label={`Swap ${hex} back into palette`}
+                  className="swap-back fa fa-refresh"
+                  onClick={() => swapColor(i, original)}
+                />
+              )}
+              <button
+                type="button"
+                aria-label="Remove color from palette"
+                className={classNames('remove-color fa fa-trash', {
+                  'no-replacement': !original
+                })}
+                onClick={() => {
+                  if (!isWide) {
+                    onDelete(i);
+                  }
+
+                  removeColor(i);
+                }}
+              />
+            </div>
+            <div className="row rgba-inputs">
+              <TextInput readOnly value={r} id={`r-${i}`} labelText="R" />
+              <TextInput readOnly value={g} id={`g-${i}`} labelText="G" />
+              <TextInput readOnly value={b} id={`b-${i}`} labelText="B" />
+              <TextInput readOnly value={a} id={`a-${i}`} labelText="A" />
+            </div>
+            <div className="row hex-input">
+              <TextInput readOnly value={hex} id={`hex-${i}`} labelText="HEX" />
+            </div>
+            <div className="used-as">
+              <h3 id={`cb-label-${i}`}>This color is used as...</h3>
+              <Checkbox
+                label="Text"
+                id={`text-cb-${i}`}
+                name={`color-used-as-${i}`}
+                checked={text}
+                onClick={e => {
+                  if (!e.target.type || e.target.type !== 'checkbox') {
+                    return;
+                  }
+
+                  updateColor(i, { text: e.target.checked });
+                }}
+              />
+              <Checkbox
+                label="Background"
+                id={`background-cb-${i}`}
+                name={`color-used-as-${i}`}
+                checked={background}
+                onClick={e => {
+                  if (!e.target.type || e.target.type !== 'checkbox') {
+                    return;
+                  }
+
+                  updateColor(i, { background: e.target.checked });
+                }}
+              />
+            </div>
+          </div>
+        )}
+      </Subscribe>
+    );
+  }
+}

--- a/src/components/Palette/NarrowView.css
+++ b/src/components/Palette/NarrowView.css
@@ -1,0 +1,65 @@
+.palette ul[role='tablist'] {
+  border-bottom: 0;
+}
+
+[role='tablist'] li {
+  width: 20%;
+}
+
+[role='tablist'] li .swatch {
+  width: auto;
+  height: 150px;
+}
+
+[role='tablist'] [role='tab'] {
+  position: relative;
+}
+
+[role='tablist'] [role='tab']:focus {
+  outline-offset: 3px;
+}
+
+[role='tablist'] [aria-selected='true']::after {
+  content: '';
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 0 15px 17px 15px;
+  border-color: transparent transparent #f2f2f2 transparent;
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 2;
+}
+
+[role='tablist'] [aria-selected='true']::before {
+  content: '';
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 0 16px 18px 16px;
+  border-color: transparent transparent #ccc transparent;
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1;
+}
+
+.panels [role='tabpanel'] {
+  background: #f2f2f2;
+}
+
+.panels [role='tabpanel'] .fields {
+  border: 0;
+}
+
+.panels [role='tabpanel'] .fields {
+  text-align: center;
+}
+
+.panels [role='tabpanel'] .fields .used-as {
+  display: inline-block;
+  margin: 0 auto;
+}

--- a/src/components/Palette/NarrowView.js
+++ b/src/components/Palette/NarrowView.js
@@ -1,0 +1,63 @@
+import React, { Component, Fragment } from 'react';
+import { Subscribe } from 'unstated';
+import PaletteContainer from '../../containers/PaletteContainer';
+import TabsContainer from '../../containers/TabsContainer';
+import Swatch from '../Swatch';
+import ColorConfig from '../ColorConfig';
+import './NarrowView.css';
+
+// TODO: Handle deleting active
+export default class NarrowView extends Component {
+  render() {
+    return (
+      <Subscribe to={[PaletteContainer, TabsContainer]}>
+        {(
+          { state: { colors } },
+          { setTabRef, clearTabs, onKeyDown, onClick, state: { activeTab } }
+        ) => {
+          clearTabs();
+
+          return (
+            <Fragment>
+              <ul role="tablist" aria-label="Color Palette">
+                {colors.map((c, i) => (
+                  <li
+                    key={`tab-${i}`}
+                    id={`tab-${i}`}
+                    role="tab"
+                    tabIndex={activeTab === i ? 0 : -1}
+                    aria-selected={activeTab === i}
+                    onKeyDown={onKeyDown}
+                    onClick={() => onClick(i)}
+                    ref={el => setTabRef(el, i)}
+                    aria-controls={`panel-${i}`}
+                  >
+                    <Swatch
+                      color={c.hex}
+                      number={i + 1}
+                      original={c.original && c.original.hex}
+                      type="palette"
+                    />
+                  </li>
+                ))}
+              </ul>
+              <div className="panels">
+                {colors.map((c, i) => (
+                  <div
+                    key={`panel-${i}`}
+                    className="panel"
+                    id={`panel-${i}`}
+                    aria-labelledby={`tab-${i}`}
+                    role="tabpanel"
+                  >
+                    {activeTab === i && <ColorConfig color={c} i={i} />}
+                  </div>
+                ))}
+              </div>
+            </Fragment>
+          );
+        }}
+      </Subscribe>
+    );
+  }
+}

--- a/src/components/Palette/WideView.js
+++ b/src/components/Palette/WideView.js
@@ -1,0 +1,37 @@
+import React, { Component } from 'react';
+import { Subscribe } from 'unstated';
+import classNames from 'classnames';
+import PaletteContainer from '../../containers/PaletteContainer';
+import Swatch from '../Swatch';
+import ColorConfig from '../ColorConfig';
+
+export default class WideView extends Component {
+  render() {
+    return (
+      <Subscribe to={[PaletteContainer]}>
+        {({ state: { colors } }) =>
+          !!colors.length && (
+            <ul>
+              {colors.map((color, i) => (
+                <li
+                  key={`color-${i}`}
+                  className={classNames({
+                    palette__fadeout: color.fadeout
+                  })}
+                >
+                  <Swatch
+                    color={color.hex}
+                    number={i + 1}
+                    original={color.original && color.original.hex}
+                    type="palette"
+                  />
+                  <ColorConfig color={color} i={i} />
+                </li>
+              ))}
+            </ul>
+          )
+        }
+      </Subscribe>
+    );
+  }
+}

--- a/src/components/Palette/index.css
+++ b/src/components/Palette/index.css
@@ -12,6 +12,16 @@
   width: 1000px;
   height: 514px;
 }
+.no-colors.narrow,
+.palette ul[role='tablist'] {
+  width: 100%;
+  height: auto; /* TODO: Add a height here for empty */
+  box-sizing: border-box;
+}
+
+.no-colors.narrow {
+  padding: 3em;
+}
 
 .palette h3 {
   font-size: 14px;

--- a/src/components/Palette/index.css
+++ b/src/components/Palette/index.css
@@ -15,7 +15,7 @@
 .no-colors.narrow,
 .palette ul[role='tablist'] {
   width: 100%;
-  height: auto; /* TODO: Add a height here for empty */
+  height: auto;
   box-sizing: border-box;
 }
 

--- a/src/components/Palette/index.js
+++ b/src/components/Palette/index.js
@@ -1,145 +1,26 @@
-import React, { Component } from 'react';
+import React, { Fragment } from 'react';
 import { Subscribe } from 'unstated';
-import { Checkbox } from 'cauldron-react';
-import classNames from 'classnames';
 import PaletteContainer from '../../containers/PaletteContainer';
-import Swatch from '../Swatch';
-import TextInput from '../TextInput';
+import WideView from './WideView';
+import NarrowView from './NarrowView';
 import './index.css';
 
-export default class Palette extends Component {
-  render() {
-    return (
-      <Subscribe to={[PaletteContainer]}>
-        {({ removeColor, updateColor, swapColor, state: { colors } }) => (
+export default function Pallette() {
+  return (
+    <Subscribe to={[PaletteContainer]}>
+      {({ state: { isWide, colors } }) => (
+        <Fragment>
+          <h2>{`Palette (${colors.length} of 5 colors added)`}</h2>
           <div className="palette">
-            <h2>{`Palette (${colors.length} of 5 colors added)`}</h2>
-            {!colors.length ? (
-              <div className="no-colors">Add some colors!</div>
-            ) : (
-              <ul>
-                {colors.map(
-                  (
-                    {
-                      hex,
-                      text,
-                      background,
-                      rgba: [r, g, b, a],
-                      original,
-                      fadeout
-                    },
-                    i
-                  ) => (
-                    <li
-                      key={`color-${i}`}
-                      className={classNames({
-                        palette__fadeout: fadeout
-                      })}
-                    >
-                      <Swatch
-                        color={hex}
-                        number={i + 1}
-                        original={original && original.hex}
-                        type="palette"
-                      />
-                      <div
-                        className="fields"
-                        role="group"
-                        aria-labelledby={`cb-label-${i}`}
-                      >
-                        <div className="row">
-                          {original && (
-                            <button
-                              aria-label={`Swap ${hex} back into palette`}
-                              className="swap-back fa fa-refresh"
-                              onClick={() => swapColor(i, original)}
-                            />
-                          )}
-                          <button
-                            type="button"
-                            aria-label="Remove color from palette"
-                            className={classNames('remove-color fa fa-trash', {
-                              'no-replacement': !original
-                            })}
-                            onClick={() => removeColor(i)}
-                          />
-                        </div>
-                        <div className="row rgba-inputs">
-                          <TextInput
-                            readOnly
-                            value={r}
-                            id={`r-${i}`}
-                            labelText="R"
-                          />
-                          <TextInput
-                            readOnly
-                            value={g}
-                            id={`g-${i}`}
-                            labelText="G"
-                          />
-                          <TextInput
-                            readOnly
-                            value={b}
-                            id={`b-${i}`}
-                            labelText="B"
-                          />
-                          <TextInput
-                            readOnly
-                            value={a}
-                            id={`a-${i}`}
-                            labelText="A"
-                          />
-                        </div>
-                        <div className="row hex-input">
-                          <TextInput
-                            readOnly
-                            value={hex}
-                            id={`hex-${i}`}
-                            labelText="HEX"
-                          />
-                        </div>
-                        <h3 id={`cb-label-${i}`}>This color is used as...</h3>
-                        <Checkbox
-                          label="Text"
-                          id={`text-cb-${i}`}
-                          name={`color-used-as-${i}`}
-                          checked={text}
-                          onClick={e => {
-                            if (
-                              !e.target.type ||
-                              e.target.type !== 'checkbox'
-                            ) {
-                              return;
-                            }
-
-                            updateColor(i, { text: e.target.checked });
-                          }}
-                        />
-                        <Checkbox
-                          label="Background"
-                          id={`background-cb-${i}`}
-                          name={`color-used-as-${i}`}
-                          checked={background}
-                          onClick={e => {
-                            if (
-                              !e.target.type ||
-                              e.target.type !== 'checkbox'
-                            ) {
-                              return;
-                            }
-
-                            updateColor(i, { background: e.target.checked });
-                          }}
-                        />
-                      </div>
-                    </li>
-                  )
-                )}
-              </ul>
+            {!colors.length && (
+              <div className={`no-colors ${!isWide ? 'narrow' : ''}`}>
+                Add some colors!
+              </div>
             )}
+            {isWide ? <WideView /> : <NarrowView />}
           </div>
-        )}
-      </Subscribe>
-    );
-  }
+        </Fragment>
+      )}
+    </Subscribe>
+  );
 }

--- a/src/components/ResultsForm/index.css
+++ b/src/components/ResultsForm/index.css
@@ -5,6 +5,12 @@
   align-items: center;
 }
 
+.results.narrow form {
+  flex-direction: row;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
 .results .dqpl-field-wrap {
   margin: 0 8px;
 }
@@ -20,4 +26,8 @@
 .results .dqpl-checkbox-wrap {
   align-self: flex-end;
   margin-bottom: 3px;
+}
+
+.results.narrow .dqpl-checkbox-wrap {
+  align-self: flex-end;
 }

--- a/src/components/ResultsForm/index.js
+++ b/src/components/ResultsForm/index.js
@@ -10,8 +10,8 @@ export default class ResultsForm extends Component {
   render() {
     return (
       <Subscribe to={[PaletteContainer]}>
-        {({ updateResultsSettings, state: { results } }) => (
-          <div className="results">
+        {({ updateResultsSettings, state: { results, isWide } }) => (
+          <div className={`results ${!isWide ? 'narrow' : ''}`}>
             <h2>Results</h2>
             <form className="row" onSubmit={e => e.preventDefault()}>
               <TextInput

--- a/src/components/Swatch/index.css
+++ b/src/components/Swatch/index.css
@@ -9,6 +9,7 @@
   overflow: hidden;
   text-overflow: fade;
   padding: 10px;
+  transition: all 400ms;
 }
 
 .palette > ul > li:not(:first-of-type) .swatch {
@@ -33,4 +34,23 @@
   left: auto;
   right: 8px;
   box-shadow: inset 0 0 0 4px #f2f2f2;
+}
+
+@media (max-width: 1034px) {
+  .swatch {
+    width: 150px;
+    height: 150px;
+  }
+}
+
+@media (max-width: 760px) {
+  .swatch {
+    width: 100px;
+    height: 100px;
+  }
+
+  .swatch .swatch-id {
+    width: 22px;
+    height: 22px;
+  }
 }

--- a/src/containers/PaletteContainer.js
+++ b/src/containers/PaletteContainer.js
@@ -1,5 +1,7 @@
 import { Container } from 'unstated';
 
+const MIN_WIDTH = 1034;
+const isWindowWide = () => window.innerWidth >= MIN_WIDTH;
 const initialState = {
   colors: [],
   results: {
@@ -9,11 +11,27 @@ const initialState = {
     groupBy: 'background',
     includeBlackAndWhite: false,
     combinations: []
-  }
+  },
+  isWide: isWindowWide()
 };
 
 export default class PaletteContainer extends Container {
   state = initialState;
+
+  constructor() {
+    super();
+    window.addEventListener('resize', this.onResize);
+  }
+
+  onResize = () => {
+    const wasWide = this.state.isWide;
+    const isWide = isWindowWide();
+
+    if (wasWide !== isWide) {
+      this.setState({ isWide });
+    }
+  };
+
   /**
    * Adds a new color to the pallete
    * @param {Object} data An object containing: hex, rgba, type (background or text)

--- a/src/containers/TabsContainer.js
+++ b/src/containers/TabsContainer.js
@@ -1,0 +1,41 @@
+import { Container } from 'unstated';
+
+export default class PaletteContainer extends Container {
+  tabs = [];
+  state = { activeTab: 0 };
+
+  clearTabs = () => (this.tabs = []);
+  setTabRef = (el, i) => (this.tabs[i] = el);
+  onClick = i => this.setState({ activeTab: i });
+  focusActive = () => this.tabs[this.state.activeTab].focus();
+  onDelete = i => {
+    if (i === this.tabs.length - 1 && i !== 0) {
+      this.setState({ activeTab: i - 1 }, this.focusActive);
+      return;
+    }
+
+    this.focusActive();
+  };
+  onKeyDown = e => {
+    const { activeTab } = this.state;
+
+    switch (e.key) {
+      case 'ArrowLeft': {
+        e.preventDefault();
+        const prev = activeTab === 0 ? this.tabs.length - 1 : activeTab - 1;
+        this.setState({ activeTab: prev });
+        this.tabs[prev].focus();
+        break;
+      }
+      case 'ArrowRight': {
+        e.preventDefault();
+        const next = activeTab === this.tabs.length - 1 ? 0 : activeTab + 1;
+        this.setState({ activeTab: next });
+        this.tabs[next].focus();
+        break;
+      }
+      default:
+        break;
+    }
+  };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -7,7 +7,9 @@ body {
   padding: 0;
 }
 
-*, *:before, *:after {
+*,
+*:before,
+*:after {
   box-sizing: inherit;
 }
 
@@ -61,11 +63,19 @@ body .dqpl-top-bar > ul li:last-child {
   position: absolute;
 }
 
-[role=textbox], [role=textbox]:hover {
+[role='textbox'],
+[role='textbox']:hover {
   border: 0;
   margin: 0;
 }
 
 .dqpl-combobox {
   background: #fff;
+}
+
+@media (max-width: 1034px) {
+  body .dqpl-layout .dqpl-main-content {
+    width: auto;
+    margin: 0;
+  }
 }


### PR DESCRIPTION
resolves #48

_At 1034px the palette controls turn in to a tablist_

# Changes
- Adds new <NarrowView /> component which is accessible tabs for the palette itself
- ensures tabs don't get in bad state if palette color is deleted
- Adds several breakpoint layout changes to the results
- lots of css (sorry!)

## Wide view:
<img width="1049" alt="wide view palette" src="https://user-images.githubusercontent.com/3180185/50045994-1b301e00-0051-11e9-98bb-3bced56af6fc.png">

## Narrow view:
<img width="704" alt="wide view palette" src="https://user-images.githubusercontent.com/3180185/50045997-1bc8b480-0051-11e9-8f04-0253ab8cf788.png">

## Narrow results view 1:
<img width="503" alt="narrow view results 1" src="https://user-images.githubusercontent.com/3180185/50045995-1bc8b480-0051-11e9-943c-f4e127c5ee0b.png">

## Narrow results view 2:
<img width="709" alt="narrow view results 2" src="https://user-images.githubusercontent.com/3180185/50045996-1bc8b480-0051-11e9-8917-ecc646511d54.png">


